### PR TITLE
Update jekyll-gh-pages.yml

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -10,7 +10,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -48,3 +48,22 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # Release job
+  release:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: "v${{ github.run_number }}"
+          release_name: "Deployed Site v${{ github.run_number }}"
+          body: "The latest version of the website is now live at: [${{ steps.deployment.outputs.page_url }}](${{ steps.deployment.outputs.page_url }})"
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for deploying a Jekyll site to GitHub Pages. The most important changes include updating permissions and adding a new job for creating a release after deployment.

Changes to permissions:

* Updated the `contents` permission from `read` to `write` to allow deployment to GitHub Pages.

New job for creating a release:

*  Added a new job named `release` that runs after the `deploy` job. This job checks out the repository and creates a new release with a tag name and release name based on the current run number, and includes a link to the deployed site.